### PR TITLE
[R/Q] android.bp: Remove hidltransport and hwbinder from shared libs

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -10,9 +10,7 @@ cc_binary {
     shared_libs: [
         "libhidlbase",
         "libcutils",
-        "libhidltransport",
         "liblog",
-        "libhwbinder",
         "libutils",
         "libhardware",
         "android.hardware.vibrator@1.0",


### PR DESCRIPTION
In Android R libhwbinder and libhidltransport are no longer available to use.
Thus let's remove the libraries.