### PR TITLE
[LA.VENDOR.1.0] fix compilation

### DIFF
--- a/aidl/Android.bp
+++ b/aidl/Android.bp
@@ -13,7 +13,6 @@ cc_library_shared {
         "libutils",
         "liblog",
         "libqtivibratoreffect",
-        "libsoc_helper",
         "libbinder_ndk",
         "android.hardware.vibrator-V2-ndk_platform",
     ],

--- a/aidl/Vibrator.cpp
+++ b/aidl/Vibrator.cpp
@@ -43,9 +43,6 @@
 #include "effect.h"
 #endif
 
-extern "C" {
-#include "libsoc_helper.h"
-}
 namespace aidl {
 namespace android {
 namespace hardware {


### PR DESCRIPTION
[apparently libsoc is some proprietary component](https://developer.qualcomm.com/forum/qdn-forums/software/snapdragon-llvm-compiler-android/68288)