### PR TITLE
Android.bp: Rename changed shared libraries

### DIFF
--- a/aidl/Android.bp
+++ b/aidl/Android.bp
@@ -14,7 +14,7 @@ cc_library_shared {
         "liblog",
         "libqtivibratoreffect",
         "libbinder_ndk",
-        "android.hardware.vibrator-V2-ndk_platform",
+        "android.hardware.vibrator-V2-ndk",
     ],
     export_include_dirs: ["include"]
 }
@@ -36,7 +36,7 @@ cc_binary {
         "libutils",
         "libbase",
         "libbinder_ndk",
-        "android.hardware.vibrator-V2-ndk_platform",
+        "android.hardware.vibrator-V2-ndk",
         "vendor.qti.hardware.vibrator.impl",
     ],
 }


### PR DESCRIPTION
Looks like that in Android 13 these libraries had their _platform postfix removed.

This fixes the build error.

Keep in mind that while this fixes this issue on A13 it has to be tested on
A12 and its very likely it may not work there.

This may be solvable in better way with GO. Thats why im marking it as DRAFT.
