### PR TITLE
[2.0.r1] init.rc: Start service when haptics driver is ready

### DIFF
--- a/aidl/vendor.qti.hardware.vibrator.service.rc
+++ b/aidl/vendor.qti.hardware.vibrator.service.rc
@@ -2,6 +2,9 @@ service vendor.qti.vibrator /vendor/bin/hw/vendor.qti.hardware.vibrator.service
     class hal
     user system
     group system input
+    disabled
 
-on late-init
+on boot
+    wait /sys/class/leds/vibrator/activate
     write /sys/class/leds/vibrator/trigger "transient"
+    start vendor.qti.vibrator


### PR DESCRIPTION
Some devices have haptics that require firmware for their
operation, such as the CS40L25A in Sagami devices. Since
the service lacks a retry mechanism, add a wait for
/sys/class/leds/vibrator/activate, which is an indicator of
haptics readiness, and start the service only after that.