### PR TITLE
[2.0.r1] vibrator: Prevent unintentional closure of valid device file descriptor

### DIFF
--- a/aidl/Vibrator.cpp
+++ b/aidl/Vibrator.cpp
@@ -142,6 +142,7 @@ InputFFDevice::InputFFDevice()
                     soc_name == "KALAMA")
                     mSupportExternalControl = true;
             }
+            break;
         }
 
         close(fd);


### PR DESCRIPTION
In commit https://github.com/sonyxperiadev/vendor-qcom-opensource-vibrator/commit/3d529b9efc342b6071588e86d5982dc374690844, a break statement was inadvertently
removed during the process of removing a dependency on a
proprietary library. As a result, when a valid device is
detected, the file descriptor is being closed incorrectly,
preventing any further communication with the device.

This commit restores the missing break statement, ensuring
that valid device file descriptor remains open and usable
for subsequent operations.