### PR TITLE
[4.0.r1] Get rid of proprietary libsoc_helper + fix for Wformat errors

### DIFF
--- a/aidl/Android.bp
+++ b/aidl/Android.bp
@@ -13,7 +13,6 @@ cc_library_shared {
         "libutils",
         "liblog",
         "libqtivibratoreffect",
-        "libsoc_helper",
         "libbinder_ndk",
         "android.hardware.vibrator-V2-ndk",
         "vendor.qti.hardware.vibratorOL.impl",

--- a/aidl/VibratorCL/Android.bp
+++ b/aidl/VibratorCL/Android.bp
@@ -6,8 +6,7 @@ cc_library_shared {
     cflags: COMMON_CFLAGS,
     vendor: true,
     srcs: ["Vibrator.cpp"],
-    include_dirs: ["vendor/qcom/opensource/pal/inc",
-                   "vendor/qcom/proprietary/args/"],
+    include_dirs: ["vendor/qcom/opensource/pal/inc"],
     header_libs: [
         "libspf-headers",
         "libarosal_headers",

--- a/aidl/VibratorCL/Vibrator.cpp
+++ b/aidl/VibratorCL/Vibrator.cpp
@@ -330,7 +330,7 @@ int32_t HapticsSetParameters(uint32_t param_mode, pal_param_haptics_cnfg_t paylo
             memcpy((uint8_t*) hpconf->buffer_ptr,
                 (uint8_t *)&VibratorCL::PcmEffectInfo[GlobaleffectId].data[0], hpconf->buffer_size);
         }
-        ALOGE("%s : size of buffer %d", __func__, sizeof(payload.buffer_ptr));
+        ALOGE("%s : size of buffer %lu", __func__, sizeof(payload.buffer_ptr));
         status =  pal_stream_set_param(pal_stream_handle_, param_mode, param_payload);
 
         break;
@@ -627,7 +627,7 @@ void VibratorCL::composePlayThread(const std::vector<CompositeEffect>& composite
             stop = std::chrono::high_resolution_clock::now();
 
             duration = duration_cast<std::chrono::milliseconds>(stop - start) - std::chrono::milliseconds(COMPOSE_EFFECT_DURATION_INMS);
-            ALOGD("Delay in getting Waveform complete event: %d", duration);
+            ALOGD("Delay in getting Waveform complete event: %lld", duration.count());
         }
     }
 

--- a/aidl/VibratorOL/Android.bp
+++ b/aidl/VibratorOL/Android.bp
@@ -7,12 +7,12 @@ cc_library_shared {
         "VibratorOffload.cpp",
     ],
     shared_libs: [
+        "libbase",
         "libcutils",
         "libutils",
         "liblog",
         "libqtivibratoreffect",
         "libqtivibratoreffectoffload",
-        "libsoc_helper",
         "libbinder_ndk",
         "android.hardware.vibrator-V2-ndk",
     ],

--- a/aidl/VibratorOL/Vibrator.cpp
+++ b/aidl/VibratorOL/Vibrator.cpp
@@ -39,15 +39,12 @@
 #include <sys/epoll.h>
 #include <sys/poll.h>
 #include <thread>
+#include <android-base/file.h>
 
 #include "Vibrator.h"
 #ifdef USE_EFFECT_STREAM
 #include "effect.h"
 #endif
-
-extern "C" {
-#include "libsoc_helper.h"
-}
 
 namespace aidl {
 namespace android {
@@ -84,7 +81,6 @@ InputFFDevice::InputFFDevice()
     const char *INPUT_DIR = "/dev/input/";
     char name[NAME_BUF_SIZE];
     int fd, ret;
-    soc_info_v0_1_t soc;
 
     mVibraFd = INVALID_VALUE;
     mSupportGain = false;
@@ -143,17 +139,14 @@ InputFFDevice::InputFFDevice()
             if (test_bit(FF_GAIN, ffBitmask))
                 mSupportGain = true;
 
-            get_soc_info(&soc);
-            ALOGD("msm CPU SoC ID: %d\n", soc.msm_cpu);
-            switch (soc.msm_cpu) {
-            case MSM_CPU_KALAMA:
-            case MSM_CPU_PINEAPPLE:
-            case MSM_CPU_SUN:
-                mSupportExternalControl = true;
-                break;
-            default:
-                mSupportExternalControl = false;
-                break;
+            const std::string soc_name_sysfs = "/sys/devices/soc0/machine";
+            std::string soc_name;
+            if (::android::base::ReadFileToString(soc_name_sysfs, &soc_name)) {
+                ALOGD("msm CPU SoC name: %s\n", soc_name.c_str());
+                if (soc_name == "KALAMA" ||
+                    soc_name == "PINEAPPLE" ||
+                    soc_name == "SUN")
+                    mSupportExternalControl = true;
             }
             break;
         }

--- a/aidl/VibratorOL/VibratorOffload.cpp
+++ b/aidl/VibratorOL/VibratorOffload.cpp
@@ -49,10 +49,6 @@
 #include "Vibrator.h"
 #include "VibratorPatterns.h"
 
-extern "C" {
-#include "libsoc_helper.h"
-}
-
 namespace aidl {
 namespace android {
 namespace hardware {

--- a/aidl/vendor.qti.hardware.vibrator.service.rc
+++ b/aidl/vendor.qti.hardware.vibrator.service.rc
@@ -2,6 +2,9 @@ service vendor.qti.vibrator /vendor/bin/hw/vendor.qti.hardware.vibrator.service
     class hal
     user system
     group system input
+    disabled
 
-on late-init
+on boot
+    wait /sys/class/leds/vibrator/activate
     write /sys/class/leds/vibrator/trigger "transient"
+    start vendor.qti.vibrator


### PR DESCRIPTION
- Get rid of proprietary libsoc_helper dependency
Get SoC name from /sys/devices/soc0/machine sysfs
instead of proprietary libsoc_helper library.

- Start service when haptics driver is ready.
Some devices have haptics that require firmware for their
operation, such as the CS40L25A in Nagara devices. Since
the service lacks a retry mechanism, add a wait for
/sys/class/leds/vibrator/activate, which is an indicator of
haptics readiness, and start the service only after that.